### PR TITLE
iOS Colors.yellow paints red

### DIFF
--- a/ios/Classes/FIConvertUtils.m
+++ b/ios/Classes/FIConvertUtils.m
@@ -302,7 +302,7 @@ static NSDictionary *mixBlendModeDict;
 }
 
 - (float)g {
-  return [self.map[@"color"][@"b"] floatValue] / 255;
+  return [self.map[@"color"][@"g"] floatValue] / 255;
 }
 
 - (float)b {


### PR DESCRIPTION
Using this library if you use Colors.yellow on iOS the color is red. This is due to green being incorrectly mapped to the blue value.