### PR TITLE
fix: memory leak rotating cropping, closes #85

### DIFF
--- a/ios/Classes/FIEPlugin.m
+++ b/ios/Classes/FIEPlugin.m
@@ -66,7 +66,11 @@ typedef void (^VoidBlock)(void);
 }
 
 - (void)asyncExec:(VoidBlock)block {
-  dispatch_async(_queue, block);
+  dispatch_async(_queue, ^(){
+      @autoreleasepool {
+          block();
+      }
+  });
 }
 
 - (void)handleMerge:(id)args

--- a/ios/Classes/FIUIImageHandler.m
+++ b/ios/Classes/FIUIImageHandler.m
@@ -143,6 +143,7 @@
   CGRect rect = CGRectMake(option.x, option.y, option.width, option.height);
   CGImageRef resultCg = CGImageCreateWithImageInRect(cg, rect);
   outImage = [UIImage imageWithCGImage:resultCg];
+  CGImageRelease(resultCg);
 }
 
 #pragma mark rotate


### PR DESCRIPTION
Use @Allen0505's  code from the ticket to fix the memory leaks as I stumbled upon the same problem and needed a fix!
Thanks, Allen :) 

(My iPhone 6s+ didn't even manage three rotations of [this](https://sample-videos.com/img/Sample-png-image-30mb.png) 30MB test png) without the fix)