### PR TITLE
fixes ColorOption.contrast (issue #105)

### DIFF
--- a/image_editor_platform_interface/CHANGELOG.md
+++ b/image_editor_platform_interface/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGE LOG
 
+## 1.0.1
+
+- Fix invalid matrix with `ColorOption.contrast`.
+
 ## 1.0.0
 
 Initial version, The platform interface API of [image_editor][].

--- a/image_editor_platform_interface/lib/src/option/color.dart
+++ b/image_editor_platform_interface/lib/src/option/color.dart
@@ -117,6 +117,11 @@ class ColorOption implements Option {
 
   factory ColorOption.contrast(double contrast) {
     final m = List<double>.from(defaultColorMatrix);
+    // final double translate = 255.0 * (1 - contrast) / 2
+    final double translate = (1 - contrast) * 127.5; // faster
+    m[4] = translate;
+    m[9] = translate;
+    m[14] = translate;
     m[0] = contrast;
     m[6] = contrast;
     m[12] = contrast;

--- a/image_editor_platform_interface/lib/src/option/color.dart
+++ b/image_editor_platform_interface/lib/src/option/color.dart
@@ -115,11 +115,10 @@ class ColorOption implements Option {
     return ColorOption.scale(brightness, brightness, brightness, 1);
   }
 
+  /// The contrast translate follows the guide:
+  /// https://docs.rainmeter.net/tips/colormatrix-guide.
   factory ColorOption.contrast(double contrast) {
     final m = List<double>.from(defaultColorMatrix);
-
-    /// The contrast translate follows the guide at:
-    /// https://docs.rainmeter.net/tips/colormatrix-guide
 
     // final double translate = 255.0 * (1 - contrast) / 2
     final double translate = (1 - contrast) * 127.5; // faster

--- a/image_editor_platform_interface/lib/src/option/color.dart
+++ b/image_editor_platform_interface/lib/src/option/color.dart
@@ -117,6 +117,10 @@ class ColorOption implements Option {
 
   factory ColorOption.contrast(double contrast) {
     final m = List<double>.from(defaultColorMatrix);
+
+    /// The contrast translate follows the guide at:
+    /// https://docs.rainmeter.net/tips/colormatrix-guide
+
     // final double translate = 255.0 * (1 - contrast) / 2
     final double translate = (1 - contrast) * 127.5; // faster
     m[4] = translate;

--- a/image_editor_platform_interface/pubspec.yaml
+++ b/image_editor_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: image_editor_platform_interface
 description: Edit your image data and output to file/memory on Android and iOS.
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/fluttercandies/flutter_image_editor
 
 environment:

--- a/image_editor_platform_interface/test/color_option_test.dart
+++ b/image_editor_platform_interface/test/color_option_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_editor_platform_interface/src/option/edit_options.dart';
+
+void main() {
+  test('contrast = 1 should give us the default matrix', () {
+    expect(ColorOption.contrast(1).matrix, defaultColorMatrix);
+  });
+  test(
+    'contrast = 0 should have zeros in the diameter, '
+    '127.5 in last column except for the last row',
+    () {
+      final matrix = List.filled(defaultColorMatrix.length, 0.0);
+      matrix[4] = 127.5;
+      matrix[9] = 127.5;
+      matrix[14] = 127.5;
+      matrix[18] = 1;
+      expect(ColorOption.contrast(0).matrix, matrix);
+    },
+  );
+}

--- a/runnable.sh
+++ b/runnable.sh
@@ -20,12 +20,18 @@ check_code(){
     echo "Generate docs in $PWD"
     dart pub global run dartdoc
 
-    # If have example folder, analyse example code
+    # Analyze if the "example" folder exists.
     if [ -d "example" ]; then
         echo "Analyse example code in $PWD"
         cd example
         flutter pub get
         flutter analyze lib
+    fi
+
+    # Run tests if the "test" folder exists.
+    if [ -d "test" ]; then
+        echo "Running tests in $PWD"
+        flutter test
     fi
 }
 


### PR DESCRIPTION
The current matrix for contrast is identical to the brightness matrix. The modification is based on the following guide:

https://docs.rainmeter.net/tips/colormatrix-guide/

and tested, too.