### PR TITLE
Fix: Create JPEG images without embedded ICC profile

### DIFF
--- a/image_editor_common/ios/Classes/EditorUIImageHandler.m
+++ b/image_editor_common/ios/Classes/EditorUIImageHandler.m
@@ -114,7 +114,16 @@ UIImage *getImageFromCGContext(CGContextRef context) {
     if (fmt.format == 0) {
         return UIImagePNGRepresentation(outImage);
     } else {
-        return UIImageJPEGRepresentation(outImage, ((CGFloat) fmt.quality) / 100);
+        NSMutableData *data = [NSMutableData new];
+        CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)data, kUTTypeJPEG, 1, NULL);
+        NSDictionary *options = @{
+            (id)kCGImageDestinationLossyCompressionQuality : @(((CGFloat)fmt.quality) / 100),
+            (id)kCGImageDestinationOptimizeColorForSharing: (id)kCFBooleanTrue
+        };
+        CGImageDestinationAddImage(imageDestination, outImage.CGImage, (CFDictionaryRef)options);
+        CGImageDestinationFinalize(imageDestination);
+        CFRelease(imageDestination);
+        return data;
     }
 }
 

--- a/image_editor_common/ios/Classes/EditorUIImageHandler.m
+++ b/image_editor_common/ios/Classes/EditorUIImageHandler.m
@@ -7,6 +7,8 @@
 
 #import "EditorUIImageHandler.h"
 #import <CoreImage/CIFilterBuiltins.h>
+#import <ImageIO/ImageIO.h>
+#import <MobileCoreServices/MobileCoreServices.h>
 
 
 void releaseCGContext(CGContextRef ref) {

--- a/image_editor_common/ios/Classes/FIMerger.m
+++ b/image_editor_common/ios/Classes/FIMerger.m
@@ -7,6 +7,8 @@
 
 #import "FIMerger.h"
 #import "EditorUIImageHandler.h"
+#import <ImageIO/ImageIO.h>
+#import <MobileCoreServices/MobileCoreServices.h>
 
 @implementation FIMerger
 

--- a/image_editor_common/ios/Classes/FIMerger.m
+++ b/image_editor_common/ios/Classes/FIMerger.m
@@ -35,7 +35,16 @@
     if (fmt.format == 0) {
         return UIImagePNGRepresentation(image);
     } else {
-        return UIImageJPEGRepresentation(image, ((CGFloat)fmt.quality) / 100);
+        NSMutableData *data = [NSMutableData new];
+        CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)data, kUTTypeJPEG, 1, NULL);
+        NSDictionary *options = @{
+            (id)kCGImageDestinationLossyCompressionQuality : @(((CGFloat)fmt.quality) / 100),
+            (id)kCGImageDestinationOptimizeColorForSharing: (id)kCFBooleanTrue
+        };
+        CGImageDestinationAddImage(imageDestination, image.CGImage, (CFDictionaryRef)options);
+        CGImageDestinationFinalize(imageDestination);
+        CFRelease(imageDestination);
+        return data;
     }
 }
 


### PR DESCRIPTION
`UIImageJPEGRepresentation` encoded image included Apple Generic RGB profile by default. But Flutter doesn't decode them with ICC profile, and the result may have slightly color shifted.

I don't find any documented way to create JPEG on iOS without embedded ICC profile. But I found that using Image I/O framework with OptimizeColorForSharing=True will not include Apple Generic RGB profile. So Flutter can display them correctly.

This pull request is using Image I/O framework to encode JPEG on iOS.